### PR TITLE
Fix foreach error when json_decode returns null

### DIFF
--- a/src/Parser/JsonParser.php
+++ b/src/Parser/JsonParser.php
@@ -20,6 +20,10 @@ class JsonParser implements JsonParserInterface
     {
         $dataList = json_decode($dataString);
 
+        if (!is_array($dataList)) {
+            throw new \RuntimeException(sprintf('Failed to parse JSON response: %s', json_last_error_msg()));
+        }
+
         $valueList = [];
 
         foreach ($dataList as $data) {


### PR DESCRIPTION
## Summary
- Add null check after `json_decode()` in `JsonParser::parse()` to prevent `foreach()` warning on PHP 8.x
- Throws a descriptive `RuntimeException` with `json_last_error_msg()` instead of silently failing

## Test plan
- [x] Ran `luft:fetch` command successfully — fetched 20,373 values without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)