### PR TITLE
Update league/csv version constraint to ^9.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-iconv": "*",
         "guzzlehttp/guzzle": "^7.2",
         "jms/serializer-bundle": "^5.0",
-        "league/csv": "^9.6",
+        "league/csv": "^9.28",
         "luft-jetzt/luft-api-bundle": "*",
         "nesbot/carbon": "^3.0@dev",
         "symfony/console": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41b17027602ed3bad85b07f780291e32",
+    "content-hash": "789ec1eecc208e1bc6c08e1ecc98bb83",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",


### PR DESCRIPTION
## Summary
- Bump league/csv constraint from ^9.6 to ^9.28
- Package was already at 9.28.0 (installed during Symfony 7.4 update)
- Ensures PHP 8.4 compatibility for escape parameter handling

## Test plan
- [x] `composer update` erfolgreich
- [x] `php bin/console` läuft fehlerfrei

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)