### PR TITLE
Add batching to LuftFetchCommand to avoid API timeout

### DIFF
--- a/src/Command/LuftFetchCommand.php
+++ b/src/Command/LuftFetchCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class LuftFetchCommand extends Command
 {
+    private const int BATCH_SIZE = 1000;
+
     public function __construct(protected SourceFetcherInterface $sourceFetcher, protected ValueApiInterface $valueApi)
     {
         parent::__construct();
@@ -43,9 +45,18 @@ class LuftFetchCommand extends Command
             }, $valueList));
         }
 
-        $this->valueApi->putValues($valueList);
+        $batches = array_chunk($valueList, self::BATCH_SIZE);
 
-        $io->success(sprintf('Send %d values to Luft api', count($valueList)));
+        $io->progressStart(count($batches));
+
+        foreach ($batches as $batch) {
+            $this->valueApi->putValues($batch);
+            $io->progressAdvance();
+        }
+
+        $io->progressFinish();
+
+        $io->success(sprintf('Sent %d values in %d batches to Luft api', count($valueList), count($batches)));
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
## Summary
- Split value push into batches of 1000 values per request
- Fixes idle timeout when sending ~20,000 values in a single PUT request
- Adds progress bar showing batch progress
- Tested successfully: 20,359 values sent in 21 batches without errors

## Test plan
- [x] `php bin/console luft:fetch` — 20,359 values in 21 batches, no timeout
- [x] 27 Tests grün
- [x] PHPStan level 6 — 0 errors

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)