### PR TITLE
Restore StationLoadCommand for loading stations from sensor.community

### DIFF
--- a/src/Command/StationLoadCommand.php
+++ b/src/Command/StationLoadCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\StationLoader\StationLoaderInterface;
+use Caldera\LuftApiBundle\Api\StationApiInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'luft:load-stations',
+    description: 'Load station list from sensor.community and push into Luft.jetzt api'
+)]
+class StationLoadCommand extends Command
+{
+    private const int BATCH_SIZE = 1000;
+
+    public function __construct(protected StationLoaderInterface $stationLoader, protected StationApiInterface $stationApi)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $result = $this->stationLoader->load();
+
+        $io->success(sprintf(
+            'Found %d existing stations, %d new stations and %d changed stations',
+            count($result->getExistingStationList()),
+            count($result->getNewStationList()),
+            count($result->getChangedStationList()),
+        ));
+
+        if (count($result->getNewStationList()) > 0) {
+            $batches = array_chunk(array_values($result->getNewStationList()), self::BATCH_SIZE);
+
+            $io->progressStart(count($batches));
+
+            foreach ($batches as $batch) {
+                $this->stationApi->putStations($batch);
+                $io->progressAdvance();
+            }
+
+            $io->progressFinish();
+        }
+
+        if (count($result->getChangedStationList()) > 0) {
+            $this->stationApi->postStations($result->getChangedStationList());
+        }
+
+        $io->success(sprintf(
+            'Sent %d new and %d changed stations to Luft api',
+            count($result->getNewStationList()),
+            count($result->getChangedStationList()),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/StationLoader/StationLoader.php
+++ b/src/StationLoader/StationLoader.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StationLoader;
+
+use Caldera\LuftApiBundle\Api\StationApiInterface;
+use Caldera\LuftModel\Model\Station;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class StationLoader implements StationLoaderInterface
+{
+    public function __construct(
+        protected HttpClientInterface $httpClient,
+        protected StationApiInterface $stationApi,
+        #[Autowire('%env(LUFTDATEN_API_URL)%')]
+        protected string $apiUrl,
+    ) {
+    }
+
+    public function load(): StationLoaderResult
+    {
+        $result = new StationLoaderResult();
+
+        $existingStationList = array_filter($this->stationApi->getStations(), fn (Station $station) => 'ld' === $station->getProvider());
+
+        $response = $this->httpClient->request('GET', $this->apiUrl);
+        $sensorDataList = json_decode($response->getContent(), false, 512, JSON_THROW_ON_ERROR);
+
+        $parsedStations = $this->parseStations($sensorDataList);
+
+        foreach ($parsedStations as $stationCode => $station) {
+            if (!array_key_exists($stationCode, $existingStationList)) {
+                $result->addNewStation($station);
+            } elseif ($this->hasStationChanged($existingStationList[$stationCode], $station)) {
+                $result->addChangedStation($station);
+            }
+        }
+
+        $result->setExistingStationList(array_diff_key($existingStationList, $result->getNewStationList(), $result->getChangedStationList()));
+
+        return $result;
+    }
+
+    /**
+     * @param array<\stdClass> $sensorDataList
+     *
+     * @return array<string, Station>
+     */
+    protected function parseStations(array $sensorDataList): array
+    {
+        $stations = [];
+
+        foreach ($sensorDataList as $sensorData) {
+            if (!isset($sensorData->location->id, $sensorData->location->latitude, $sensorData->location->longitude)) {
+                continue;
+            }
+
+            $stationCode = sprintf('LFTDTN%d', $sensorData->location->id);
+
+            if (array_key_exists($stationCode, $stations)) {
+                continue;
+            }
+
+            $station = new Station();
+            $station
+                ->setStationCode($stationCode)
+                ->setLatitude((float) $sensorData->location->latitude)
+                ->setLongitude((float) $sensorData->location->longitude)
+                ->setAltitude((int) $sensorData->location->altitude)
+                ->setProvider('ld');
+
+            $stations[$stationCode] = $station;
+        }
+
+        return $stations;
+    }
+
+    protected function hasStationChanged(Station $existing, Station $new): bool
+    {
+        return $existing->getLatitude() !== $new->getLatitude()
+            || $existing->getLongitude() !== $new->getLongitude()
+            || $existing->getAltitude() !== $new->getAltitude();
+    }
+}

--- a/src/StationLoader/StationLoaderInterface.php
+++ b/src/StationLoader/StationLoaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StationLoader;
+
+interface StationLoaderInterface
+{
+    public function load(): StationLoaderResult;
+}

--- a/src/StationLoader/StationLoaderResult.php
+++ b/src/StationLoader/StationLoaderResult.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StationLoader;
+
+use Caldera\LuftModel\Model\Station;
+
+class StationLoaderResult
+{
+    /** @var array<string, Station> */
+    protected array $existingStationList = [];
+
+    /** @var array<string, Station> */
+    protected array $newStationList = [];
+
+    /** @var array<string, Station> */
+    protected array $changedStationList = [];
+
+    /** @param array<string, Station> $existingStationList */
+    public function setExistingStationList(array $existingStationList): self
+    {
+        $this->existingStationList = $existingStationList;
+
+        return $this;
+    }
+
+    /** @return array<string, Station> */
+    public function getExistingStationList(): array
+    {
+        return $this->existingStationList;
+    }
+
+    public function addNewStation(Station $station): self
+    {
+        $this->newStationList[$station->getStationCode()] = $station;
+
+        return $this;
+    }
+
+    /** @return array<string, Station> */
+    public function getNewStationList(): array
+    {
+        return $this->newStationList;
+    }
+
+    public function addChangedStation(Station $station): self
+    {
+        $this->changedStationList[$station->getStationCode()] = $station;
+
+        return $this;
+    }
+
+    /** @return array<string, Station> */
+    public function getChangedStationList(): array
+    {
+        return $this->changedStationList;
+    }
+}

--- a/tests/StationLoader/StationLoaderTest.php
+++ b/tests/StationLoader/StationLoaderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\StationLoader;
+
+use App\StationLoader\StationLoader;
+use Caldera\LuftApiBundle\Api\StationApiInterface;
+use Caldera\LuftModel\Model\Station;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class StationLoaderTest extends TestCase
+{
+    public function testLoadDetectsNewStations(): void
+    {
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn([]);
+
+        $loader = $this->createLoader([$this->createSensorData(locationId: 42)], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(1, $result->getNewStationList());
+        $this->assertArrayHasKey('LFTDTN42', $result->getNewStationList());
+        $this->assertCount(0, $result->getChangedStationList());
+        $this->assertCount(0, $result->getExistingStationList());
+    }
+
+    public function testLoadDetectsExistingUnchangedStations(): void
+    {
+        $existingStation = (new Station())
+            ->setStationCode('LFTDTN42')
+            ->setLatitude(52.52)
+            ->setLongitude(13.405)
+            ->setAltitude(34)
+            ->setProvider('ld');
+
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn(['LFTDTN42' => $existingStation]);
+
+        $loader = $this->createLoader([$this->createSensorData(locationId: 42, latitude: '52.52', longitude: '13.405', altitude: '34')], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(0, $result->getNewStationList());
+        $this->assertCount(0, $result->getChangedStationList());
+        $this->assertCount(1, $result->getExistingStationList());
+    }
+
+    public function testLoadDetectsChangedStations(): void
+    {
+        $existingStation = (new Station())
+            ->setStationCode('LFTDTN42')
+            ->setLatitude(52.52)
+            ->setLongitude(13.405)
+            ->setAltitude(34)
+            ->setProvider('ld');
+
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn(['LFTDTN42' => $existingStation]);
+
+        $loader = $this->createLoader([$this->createSensorData(locationId: 42, latitude: '53.00', longitude: '13.405', altitude: '34')], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(0, $result->getNewStationList());
+        $this->assertCount(1, $result->getChangedStationList());
+        $this->assertSame(53.0, $result->getChangedStationList()['LFTDTN42']->getLatitude());
+    }
+
+    public function testLoadDeduplicatesByStationCode(): void
+    {
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn([]);
+
+        $loader = $this->createLoader([
+            $this->createSensorData(locationId: 42),
+            $this->createSensorData(locationId: 42),
+            $this->createSensorData(locationId: 42),
+        ], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(1, $result->getNewStationList());
+    }
+
+    public function testLoadSetsCorrectStationProperties(): void
+    {
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn([]);
+
+        $loader = $this->createLoader([$this->createSensorData(locationId: 99, latitude: '48.137', longitude: '11.576', altitude: '520')], $stationApi);
+
+        $result = $loader->load();
+
+        $station = $result->getNewStationList()['LFTDTN99'];
+        $this->assertSame('LFTDTN99', $station->getStationCode());
+        $this->assertSame(48.137, $station->getLatitude());
+        $this->assertSame(11.576, $station->getLongitude());
+        $this->assertSame(520, $station->getAltitude());
+        $this->assertSame('ld', $station->getProvider());
+    }
+
+    public function testLoadSkipsEntriesWithMissingLocation(): void
+    {
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn([]);
+
+        $malformed = (object) ['timestamp' => '2024-01-15 12:00:00'];
+        $loader = $this->createLoader([$malformed, $this->createSensorData(locationId: 1)], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(1, $result->getNewStationList());
+    }
+
+    public function testLoadHandlesMultipleStationsWithMixedStates(): void
+    {
+        $existingStation = (new Station())
+            ->setStationCode('LFTDTN1')
+            ->setLatitude(52.52)
+            ->setLongitude(13.405)
+            ->setAltitude(34)
+            ->setProvider('ld');
+
+        $changedStation = (new Station())
+            ->setStationCode('LFTDTN2')
+            ->setLatitude(48.0)
+            ->setLongitude(11.0)
+            ->setAltitude(500)
+            ->setProvider('ld');
+
+        $stationApi = $this->createMock(StationApiInterface::class);
+        $stationApi->method('getStations')->willReturn([
+            'LFTDTN1' => $existingStation,
+            'LFTDTN2' => $changedStation,
+        ]);
+
+        $loader = $this->createLoader([
+            $this->createSensorData(locationId: 1, latitude: '52.52', longitude: '13.405', altitude: '34'),
+            $this->createSensorData(locationId: 2, latitude: '48.5', longitude: '11.0', altitude: '500'),
+            $this->createSensorData(locationId: 3, latitude: '50.0', longitude: '8.0', altitude: '100'),
+        ], $stationApi);
+
+        $result = $loader->load();
+
+        $this->assertCount(1, $result->getExistingStationList());
+        $this->assertCount(1, $result->getChangedStationList());
+        $this->assertCount(1, $result->getNewStationList());
+    }
+
+    /**
+     * @param array<object> $sensorDataList
+     */
+    private function createLoader(array $sensorDataList, StationApiInterface $stationApi): StationLoader
+    {
+        $responseBody = json_encode($sensorDataList);
+        $httpClient = new MockHttpClient(new MockResponse($responseBody));
+
+        return new StationLoader($httpClient, $stationApi, 'https://api.luftdaten.info/static/v2/data.dust.min.json');
+    }
+
+    private function createSensorData(int $locationId = 100, string $latitude = '52.52', string $longitude = '13.405', string $altitude = '34'): object
+    {
+        return (object) [
+            'location' => (object) [
+                'id' => $locationId,
+                'latitude' => $latitude,
+                'longitude' => $longitude,
+                'altitude' => $altitude,
+            ],
+            'timestamp' => '2024-01-15 12:00:00',
+            'sensordatavalues' => [
+                (object) ['value_type' => 'P1', 'value' => '30.0'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Restores the station loading functionality that was accidentally removed as "dead code" in commit 45274af
- Without this command, new stations from sensor.community are not registered in the Luft.jetzt API, causing their measurements to be silently dropped by the `PostgisPersister`
- New command name: `luft:load-stations` (consistent with `luft:fetch` and `luft:archive`)

### Improvements over old implementation
- **Bugfix**: Existence check now correctly compares against existing stations (old code checked against raw API data)
- **Deduplication**: Same station appearing multiple times in the JSON is only processed once
- **Change detection**: Only stations with actually changed coordinates (lat/lng/altitude) are updated
- **Symfony HttpClient** instead of Guzzle (project standard since PR #36)
- **Batching** for `putStations` calls (1000 per batch), consistent with `LuftFetchCommand`

## Test plan

- [ ] Run `vendor/bin/phpunit tests/StationLoader/` — 7 new unit tests
- [ ] Run `vendor/bin/phpstan analyse` — no errors
- [ ] Run `vendor/bin/php-cs-fixer fix --dry-run` — no violations
- [ ] Run `php bin/console luft:load-stations` against live API
- [ ] Update scheduled task on server to use `luft:load-stations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)